### PR TITLE
Fix ICMP and SYN autograder issues

### DIFF
--- a/09-lab-transport-layer/driver.py
+++ b/09-lab-transport-layer/driver.py
@@ -197,6 +197,7 @@ class Scenario1(Lab4Tester):
                 'dstaddr': icmp_match.group('dstaddr'),
                 'srcport': icmp_match.group('srcport'),
                 'dstport': icmp_match.group('dstport'),
+                'msg': icmp_match.group('msg')
                 }
         if hostname != 'a':
             sys.stderr.write('ICMP error message was expected at a, not %s\n' % \
@@ -376,10 +377,10 @@ class Scenario2(Lab4Tester):
             sys.stderr.write('Expected an SYN RST packet at a or c, if anything.\n')
             return False
         host2_correct = { 
-                        'srcport': host_match.group('srcaddr'),
-                        'dstport': host_match.group('dstaddr'),
-                        'srcaddr': host_match.group('srcport'),
-                        'dstaddr': host_match.group('dstport'),
+                        'srcport': host_match.group('dstport'),
+                        'dstport': host_match.group('srcport'),
+                        'srcaddr': host_match.group('dstaddr'),
+                        'dstaddr': host_match.group('srcaddr'),
                         'flags': 'R' }
         host2_observed = {
                 'srcport': host2_match.group('srcport'),


### PR DESCRIPTION
The following issues existed with the autograder for lab 9:

#### 1. ICMP

The "msg" field was extracted for the expected ICMP message "icmp_correct", but not for the observed ICMP message, "icmp_observed". This caused the autograder to incorrectly state every time that the user's ICMP message was incorrectly formatted, because when comparing "icmp_correct" and "icmp_observed", they were different. This change fixes that, extracting the "msg" field for "icmp_observed" as well.


#### 2. SYN

The expected SYN message, "host2_correct", parses its values using the improper keys. For example, the value of 'srcport' is retrieved using the key 'srcaddr', meaning that the port values are expected to be the IP address values, and vice versa, instead of what they actually should be. This caused the autograder to incorrectly state every time that the user's SYN message was incorrectly formatted, because when comparing "host2_correct" and "host2_observed", they were different. This change fixes that.

Note, in order to get my code to pass, the fix involved swapped the parsing for the ports and addresses in "host2_corect" so that src parsed dst, and dst parsed src. I made this fix assuming that my code, which, upon receiving a TCP message, constructs a new TCP SYN message in response, swapping the dst and src values from the original TCP message, is correct. If that is not meant to happen, and a TCP SYN instead is meant to keep the dst and src the same from the original TCP message, then this logic in my PR here would be incorrect. However, I saw other places in the autograder do this swapping as well, such as lines 437 - 450, so I am fairly confident this is expected.

_My code which now passes_:
```
 new_tcp_packet = TCPHeader(
            sport = tcp_packet.dport,
            dport = tcp_packet.sport,
            ...
 )
```

_My proposed changes, which swap src and dst_:
```
 'srcport': host_match.group('dstport'),
 'dstport': host_match.group('srcport'),
 'srcaddr': host_match.group('dstaddr'),
 'dstaddr': host_match.group('srcaddr'),
```

_Lines 437 - 450 already in driver.py, which also swapp src and dst for host2_correct _:
```
  host2_correct = {
                'srcport': host_match.group('dstport'),
                'dstport': host_match.group('srcport'),
                'srcaddr': host_match.group('dstaddr'),
                'dstaddr': host_match.group('srcaddr'),
                'ack': int(host_match.group('seq')) + 1,
                'flags': 'SA' }
        host2_observed = {
                'srcport': host2_match.group('srcport'),
                'dstport': host2_match.group('dstport'),
                'srcaddr': host2_match.group('srcaddr'),
                'dstaddr': host2_match.group('dstaddr'),
                'ack': int(host2_match.group('ack')),
                'flags': host2_match.group('flags') }
```

These changes have been tested locally, the result of the changes is that running driver.py successfully passes given my code and stops giving me messages that my ICMP and SYN messages are incorrectly formatted.  